### PR TITLE
Bugfix/lazy loading

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,22 +1,32 @@
 console.log("test message");
 
-findImageSource(document.body);
+Array.from(document.querySelectorAll("img")).forEach(function observe(img) {
+  if (isImgSrc(img.src)) {
+    // Img src not waiting to be lazy loaded, so wrap immediately
+    wrap(img);
+  } else {
+    // Wait for img src to be lazy loaded before wrapping
+    var observer = new MutationObserver(function (changes) {
+      changes.forEach((change) => {
+        if (change.attributeName.includes("src")) wrap(img);
+      });
+    });
+    observer.observe(img, { attributes: true });
+  }
+});
+
+// ***
+
 function wrap(toWrap, wrapper) {
-    wrapper = wrapper || document.createElement("div");
-    toWrap.parentNode.appendChild(wrapper);
-    return wrapper.appendChild(toWrap);
+  wrapper = wrapper || document.createElement("div");
+  toWrap.parentNode.appendChild(wrapper);
+  toWrap.insertAdjacentHTML(
+    "beforebegin",
+    '<div id="backDate">Test Date</div>'
+  );
+  return wrapper.appendChild(toWrap);
 }
 
-function findImageSource(element) {
-    if (element.hasChildNodes()) {
-        element.childNodes.forEach(findImageSource);
-    } else if (element.nodeName == "IMG") {
-        console.log(element.src);
-        wrap(element);
-        element.parentNode.id = 'wrap'
-        element.insertAdjacentHTML(
-            "beforebegin",
-            '<div id="backDate">Test Date</div>'
-        );
-    }
+function isImgSrc(url) {
+  return url.match(/\.(jpeg|jpg|gif|png)$/) != null;
 }

--- a/script.js
+++ b/script.js
@@ -1,21 +1,33 @@
 console.log("test message");
 
-Array.from(document.querySelectorAll("img")).forEach(function observe(img) {
+Array.from(document.querySelectorAll("img")).forEach(addDateDiv);
+
+// ***
+function addDateDiv(img) {
+  console.log("img", img);
   if (isImgSrc(img.src)) {
     // Img src not waiting to be lazy loaded, so wrap immediately
     wrap(img);
   } else {
     // Wait for img src to be lazy loaded before wrapping
-    var observer = new MutationObserver(function (changes) {
-      changes.forEach((change) => {
-        if (change.attributeName.includes("src")) wrap(img);
-      });
-    });
-    observer.observe(img, { attributes: true });
+    observeImg(img);
   }
-});
+}
 
-// ***
+function observeImg(img) {
+  const imgObserver = new MutationObserver(observerCallback);
+
+  imgObserver.observe(img, { attributes: true });
+
+  // ***
+  function observerCallback(changes, observer) {
+    const srcChange = changes.find((c) => c.attributeName.includes("src"));
+    if (!srcChange) return;
+    wrap(img);
+    // Disconnect observer because it has accomplished its objective and is a drag on performance
+    observer.disconnect();
+  }
+}
 
 function wrap(toWrap, wrapper) {
   wrapper = wrapper || document.createElement("div");


### PR DESCRIPTION
This works perfectly on cnn.com/health. I believe that is because they are lazy loading the img source on image elements _already in the DOM_.

It works less well on other CNN pages. I believe that is because on those pages, they are adding the imgs to the DOM _after_ this script runs.

It's irritating AF, but could maybe be solved via a setTimeout.

Also, infinite scroll is an issue, cuz it's constantly rendering new images. 

Oh well, this is progress! Try it out :)